### PR TITLE
updated config to work with latest webpack

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,7 +4,7 @@ module.exports = {
         filename: './dist/bundle.js'
     },
     module: {
-        loaders: [
+        use: [
             {
                 test: /\.js$/,
                 exclude: /node_modules/


### PR DESCRIPTION
When I cloned this project, out the box it failed citing loader as the issue, changing to use instead of loader fixed this in the latest weback